### PR TITLE
Make powerline-symbols unconditional dependency

### DIFF
--- a/app-misc/powerline/metadata.xml
+++ b/app-misc/powerline/metadata.xml
@@ -49,5 +49,6 @@ feature-rich alternative is currently Bailey Ling's vim-airline project.
 		<flag name="tmux">Install tmux support files</flag>
 		<flag name="vim">Install vim support files</flag>
 		<flag name="zsh">Install zsh support files</flag>
+		<flag name="fonts">Install various fonts with powerline symbols</flag>
 	</use>
 </pkgmetadata>

--- a/app-misc/powerline/powerline-9999.ebuild
+++ b/app-misc/powerline/powerline-9999.ebuild
@@ -28,7 +28,7 @@ HOMEPAGE="http://github.com/Lokaltog/powerline"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd"
-IUSE="awesome doc bash test tmux vim zsh"
+IUSE="awesome doc bash test tmux vim zsh fonts"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 PYTHON_DEPS+="
@@ -48,7 +48,8 @@ DEPEND="${PYTHON_DEPS}
 		)
 	)"
 RDEPEND="${PYTHON_DEPS}
-	|| ( media-fonts/powerline-symbols media-fonts/powerline-fonts )
+	media-fonts/powerline-symbols
+	fonts? ( media-fonts/powerline )
 	awesome? ( >=x11-wm/awesome-3.5.1 )
 	bash? ( app-shells/bash )
 	vim? ( || (


### PR DESCRIPTION
Reasoning was described in Lokaltog/powerline#719.

---

By the way, do you know why
1. there are no Manifest files and
2. ebuild refuses to create them with the following log:
   
   ```
   (zyx-desktop:zyx:tmp/image/raiagent) 1 % ebuild app-misc/powerline/powerline-9999.ebuild manifest
   !!! Repository 'mv' is missing masters attribute in '/var/lib/layman/mv/metadata/layout.conf'
   !!! Set 'masters = gentoo' in this file for future compatibility                                                                                                                                                                               
   !!! Repository 'enlightenment' is missing masters attribute in '/var/lib/layman/enlightenment/metadata/layout.conf'                                                                                                                            
   !!! Set 'masters = gentoo' in this file for future compatibility                                                                                                                                                                               
   Appending /home/zyx/tmp/image/raiagent to PORTDIR_OVERLAY...
   !!! Repository 'mv' is missing masters attribute in '/var/lib/layman/mv/metadata/layout.conf'
   !!! Set 'masters = gentoo' in this file for future compatibility                                                                                                                                                                               
   !!! Repository 'enlightenment' is missing masters attribute in '/var/lib/layman/enlightenment/metadata/layout.conf'                                                                                                                            
   !!! Set 'masters = gentoo' in this file for future compatibility                                                                                                                                                                               
   >>> Creating Manifest for /home/zyx/tmp/image/raiagent/app-misc/powerline
   ```
   
   which looks like if it actually created Manifest.
