### PR TITLE
app-misc/powerline: fix missing IUSE 'fish'

### DIFF
--- a/app-misc/powerline/powerline-9999-r5.ebuild
+++ b/app-misc/powerline/powerline-9999-r5.ebuild
@@ -19,7 +19,7 @@ LICENSE="MIT"
 
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86 ~x86-fbsd"
-IUSE="awesome doc bash test tmux vim zsh fonts"
+IUSE="awesome doc bash fish test tmux vim zsh fonts"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 COMMON_DEPS="virtual/python-argparse"


### PR DESCRIPTION
app-misc/powerline is missing 'fish' in IUSE but uses it in RDEPEND. Therefore portage bails out due to mask:invalid.
This commit fixes this issue by simply adding fish to IUSE.
