### PR TITLE
Remove python-argparse dependency in powerline

### DIFF
--- a/app-misc/powerline/powerline-9999-r7.ebuild
+++ b/app-misc/powerline/powerline-9999-r7.ebuild
@@ -22,9 +22,7 @@ KEYWORDS="~amd64 ~ppc ~x86 ~x86-fbsd"
 IUSE="awesome doc bash fish test tmux vim zsh fonts"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-COMMON_DEPS="virtual/python-argparse"
-DEPEND="${COMMON_DEPS}
-	dev-python/setuptools
+DEPEND="dev-python/setuptools
 	doc? ( dev-python/sphinx dev-python/docutils )
 	test? (
 		|| ( >=dev-vcs/git-1.7.2 >=dev-python/pygit2-0.17 )
@@ -38,8 +36,7 @@ DEPEND="${COMMON_DEPS}
 			dev-vcs/mercurial
 		)
 	)"
-RDEPEND="${COMMON_DEPS}
-	awesome? ( >=x11-wm/awesome-3.5.1 )
+RDEPEND="awesome? ( >=x11-wm/awesome-3.5.1 )
 	media-fonts/powerline-symbols
 	fonts? ( media-fonts/powerline-symbols )
 	bash? ( app-shells/bash )


### PR DESCRIPTION
According to this message from portage:

```
!!! The following installed packages are masked:
- virtual/python-argparse-1::gentoo (masked by: package.mask)
/usr/portage/profiles/package.mask:
# Michał Górny <mgorny@gentoo.org> (6 Jul 2014)
# (on behalf of python@gentoo.org)
# The modules provided by those virtuals are built-in in all currently
# supported Python implementations. If your ebuild depends on either
# of them, please just remove the dependency. Removal in 30 days.
```
