### PR TITLE
app-misc/powerline: remove deprecated dependency on python 2.6 and add

### DIFF
--- a/app-misc/powerline/powerline-9999-r8.ebuild
+++ b/app-misc/powerline/powerline-9999-r8.ebuild
@@ -6,7 +6,7 @@ EAPI="5"
 # Enforce Bash scrictness.
 set -e
 
-PYTHON_COMPAT=( python{2_6,2_7,3_2,3_3} )
+PYTHON_COMPAT=( python{2_7,3_2,3_3,3_4} )
 
 EGIT_REPO_URI="https://github.com/Lokaltog/powerline"
 EGIT_BRANCH="develop"
@@ -36,10 +36,7 @@ DEPEND="
 		$(python_gen_cond_dep\
             'dev-vcs/bzr
 			 dev-vcs/mercurial'\
-            python{2_6,2_7})
-		$(python_gen_cond_dep\
-            'virtual/python-unittest2'\
-            python2_6)
+            python{2_7})
 	)
 "
 RDEPEND="


### PR DESCRIPTION
Python 2.6 has been removed from the tree and therefore the ebuild should not depend on python_targets_python2_6

I've added python_targets_python3_4 instead (works for me).

The actual error I get is:

!!! All ebuilds that could satisfy "powerline" have been masked.
!!! One of the following masked packages is required to complete your request:
- app-misc/powerline-9999-r8::raiagent (masked by: invalid: DEPEND: USE flag 'python_targets_python2_6' referenced in conditional 'python_targets_python2_6?' is not in IUSE)

For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.
