### PR TITLE
Mark powerline as compatible with pypy3 and remove pypy2_0

### DIFF
--- a/app-misc/powerline/powerline-9999-r16.ebuild
+++ b/app-misc/powerline/powerline-9999-r16.ebuild
@@ -6,7 +6,7 @@ EAPI="5"
 # Enforce Bash scrictness.
 set -e
 
-PYTHON_COMPAT=( python{2_7,3_2,3_3,3_4} pypy{,2_0} )
+PYTHON_COMPAT=( python{2_7,3_2,3_3,3_4} pypy{,3} )
 
 EGIT_REPO_URI="https://github.com/powerline/powerline"
 EGIT_BRANCH="develop"


### PR DESCRIPTION
As far as I can tell there is no longer such a thing as pypy2_0 python target.

Not updating other ebuilds because until powerline/powerline#1224 pypy3 support was not tested (they should actually work though).
