### PR TITLE
Remove obsolete ewarns

### DIFF
--- a/app-misc/powerline/powerline-9999-r20.ebuild
+++ b/app-misc/powerline/powerline-9999-r20.ebuild
@@ -82,10 +82,6 @@ src_unpack() {
 	# If running unit tests, clone Powerline's testing-specific "bot-ci"
 	# repository. 
 	if use test; then
-		ewarn 'Unit tests currently fail under most systems. Consider adding "-test" to "FEATURE" in "/etc/portage/make.conf".'
-		has sandbox ${FEATURES} && ewarn\
-			'Unit testing currently conflicts with Portage sandboxing. Expect numerous ignorable error messages.'
-
 		# Preserve the git branch name for the current ebuild.
 		local egit_branch_saved="${EGIT_BRANCH}"
 


### PR DESCRIPTION
This should actually be part of the #29 should I mention it in time.

Did not rename ebuild file because the only thing this change does is removing ewarns what has the only effect of user not seeing two additional messages after build (so users have no reason to want powerline be reemerged automatically).