### PR TITLE
Cataclysm-dda: Patch to add USE_XDG_DIR option in 0.9c

### DIFF
--- a/games-roguelike/cataclysm-dda/cataclysm-dda-0.9c-r3.ebuild
+++ b/games-roguelike/cataclysm-dda/cataclysm-dda-0.9c-r3.ebuild
@@ -1,0 +1,186 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+EAPI=5
+
+#FIXME: C:DDA ships with an undocumented and currently unsupported
+#"CMakeLists.txt" for building under CMake. Switch to such makefile when
+#confirmed to be reliably working.
+
+# See "COMPILING.md" in the C:DDA repository for compilation instructions.
+inherit games
+
+DESCRIPTION="Roguelike set in a post-apocalyptic world"
+HOMEPAGE="http://www.cataclysmdda.com"
+
+LICENSE="CC-BY-SA-3.0"
+SLOT="0"
+IUSE="clang lua ncurses nls sdl sound"
+REQUIRED_USE="
+	lua? ( sdl )
+	sound? ( sdl )
+	|| ( ncurses sdl )
+"
+
+RDEPEND="
+	app-arch/bzip2:= 
+	sys-libs/glibc:2.2=
+	sys-libs/zlib:=
+	lua? ( >=dev-lang/lua-5.1:0= )
+	ncurses? ( sys-libs/ncurses:5= )
+	nls? ( sys-devel/gettext:0=[nls] )
+	sdl? (
+		media-libs/libsdl2:0=
+		media-libs/sdl2-ttf:0=
+		media-libs/sdl2-image:0=[jpeg,png]
+		media-libs/freetype:2=
+	)
+	sound? (
+		media-libs/sdl2-mixer:0=
+	)
+"
+DEPEND="${RDEPEND}
+	clang? ( sys-devel/clang )
+	!clang? ( sys-devel/gcc[cxx] )
+"
+
+# Absolute path of the directory containing C:DDA data files.
+CATACLYSM_HOME="${GAMES_DATADIR}/${PN}"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+
+	EGIT_REPO_URI="https://github.com/CleverRaven/Cataclysm-DDA.git"
+	SRC_URI=""
+	KEYWORDS=""
+else
+	# Post-0.9 versions of C:DDA employ capitalized alphabetic letters rather
+	# than numbers (e.g., "0.A" rather than "1.0"). Since Portage permits
+	# version specifiers to contain only a single suffixing letter prefixed by
+	# one or more digits, we:
+	#
+	# * Encode such versions as "0.9${lowercase_letter}" in ebuild filenames.
+	# * In the ebuilds themselves (i.e., here), we:
+	#   * Manually strip the "9" in such filenames.
+	#   * Uppercase the lowercase letter in such filenames.
+	MY_PV="${PV/.9/.}"
+	MY_PV="${MY_PV^^}"
+	SRC_URI="https://github.com/CleverRaven/Cataclysm-DDA/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+	S="${WORKDIR}/Cataclysm-DDA-${MY_PV}"
+fi
+
+src_prepare() {
+	epatch ${FILESDIR}/${PV}/${P}-Add-USE_XDG_DIR-make-option.patch
+
+	# Strip the following from the the Makefile:
+	#
+	# * Hardcoded optimizations (e.g., "-O3").
+	# * g++ option "-Werror", converting compiler warnings to errors and hence
+	#   failing on the first (inevitable) warning.
+	sed -i\
+		-e '/OTHERS += /s~ -O3~~'\
+		-e '/RELEASE_FLAGS = /s~ -Werror~~'\
+		Makefile || die '"sed" failed.'
+
+	# Replace the hardcoded home directory with our Gentoo-specific directory,
+	# which *MUST* be suffixed by "/" here to satisfy code requirements.
+	sed -i -e 's~^\(\s*update_pathname("datadir", \)[^)]*\(.*\)$~\1"'${CATACLYSM_HOME}'/"\2~g'\
+		src/path_info.cpp || die '"sed" failed.'
+
+	# The Makefile assumes subdirectories "obj" and "obj/tiles" both exist,
+	# which (of course) they do not. Create such subdirectories manually.
+	mkdir -p obj/tiles || die '"mkdir" failed.'
+}
+
+src_compile() {
+	# Options passed to all ncurses- and SDL-specific emake() calls below.
+	declare -ga CATACLYSM_EMAKE_NCURSES CATACLYSM_EMAKE_SDL
+
+	# Define ncurses-specific emake() options first.
+	CATACLYSM_EMAKE_NCURSES=(
+		# Unlike all other paths defined below, ${PREFIX} is compiled into
+		# installed binaries and hence *MUST* refer to a run- rather than
+		# install-time directory (e.g., relative to ${EROOT} rather than ${ED}).
+		PREFIX="${EROOT}"usr
+
+		# Install-time directories. Since ${PREFIX} does *NOT* refer to an
+		# install-time directory, all variables defined by the Makefile relative
+		# to ${PREFIX} *MUST* be redefined here relative to ${ED}.
+		BIN_PREFIX="${ED}/${GAMES_BINDIR}"
+		DATA_PREFIX="${ED}/${CATACLYSM_HOME}"
+		LOCALE_DIR="${ED}"/usr/share/locale
+
+		# For efficiency, prefer release to debug builds.
+		RELEASE=1
+
+		# Link against Portage-provided shared libraries.
+		DYNAMIC_LINKING=1
+
+		# Write saves and configs to user-specific XDG base directories.
+		USE_XDG_DIR=1
+	)
+
+	use clang && CATACLYSM_EMAKE_NCURSES+=( CLANG=1 )
+	use lua   && CATACLYSM_EMAKE_NCURSES+=( LUA=1 )
+
+	# If enabling internationalization, do so.
+	if use nls; then
+		CATACLYSM_EMAKE_NCURSES+=( LOCALIZE=1 )
+
+		# If optional Gentoo-specific string global ${LINGUAS} is defined (e.g.,
+		# in "make.conf"), pass all such whitespace-delimited locales.
+		[[ -n "${LINGUAS+x}" ]] &&
+			CATACLYSM_EMAKE_NCURSES+=( LANGUAGES="${LINGUAS}" )
+	else
+		CATACLYSM_EMAKE_NCURSES+=( LOCALIZE=0 )
+	fi
+
+	# Define SDL- *AFTER* ncurses-specific emake() options, as the former is a
+	# strict superset of the latter.
+	CATACLYSM_EMAKE_SDL=( TILES=1 "${CATACLYSM_EMAKE_NCURSES[@]}" )
+	use sound && CATACLYSM_EMAKE_SDL+=( SOUND=1 )
+
+	# If enabling ncurses, compile the ncurses-based binary.
+	if use ncurses; then
+		einfo 'Compiling ncurses interface...'
+		emake "${CATACLYSM_EMAKE_NCURSES[@]}"
+	fi
+
+	# If enabling SDL, compile the SDL-based binary.
+	if use sdl; then
+		einfo 'Compiling SDL interface...'
+		emake "${CATACLYSM_EMAKE_SDL[@]}"
+	fi
+}
+
+src_install() {
+	# If enabling ncurses, install the ncurses-based binary.
+	if use ncurses; then
+		emake install "${CATACLYSM_EMAKE_NCURSES[@]}"
+	fi
+
+	# If enabling SDL, install the SDL-based binary.
+	if use sdl; then
+		emake install "${CATACLYSM_EMAKE_SDL[@]}"
+	fi
+
+	# Force game-specific user and group permissions.
+	prepgamesdirs
+}
+
+pkg_preinst() {
+	if has_version "=games-roguelike/cataclysm-dda-0.9c-r2"; then
+		BROKEN_SAVES_VERSION_INSTALLED=1
+	fi
+}
+
+pkg_postinst() {
+	if [[ -n $BROKEN_SAVES_VERSION_INSTALLED ]]; then
+		ewarn "The prior installed version did not save game data correctly."
+		ewarn "Consequently, existing saved game data may not be recognized"
+		ewarn "by this build."
+		ewarn " "
+	fi
+	games_pkg_postinst
+}

--- a/games-roguelike/cataclysm-dda/files/0.9c/cataclysm-dda-0.9c-Add-USE_XDG_DIR-make-option.patch
+++ b/games-roguelike/cataclysm-dda/files/0.9c/cataclysm-dda-0.9c-Add-USE_XDG_DIR-make-option.patch
@@ -1,0 +1,99 @@
+From b8afd4966c5c6e6496ce82b06bc77b44acdc4131 Mon Sep 17 00:00:00 2001
+From: Samir Benmendil <samir.benmendil@gmail.com>
+Date: Fri, 8 May 2015 07:51:30 +0100
+Subject: [PATCH] Add USE_XDG_DIR make option (fix #12315)
+
+This adds a make flag to follow the freedesktop.org XDG specs.
+---
+ Makefile          | 12 ++++++++++++
+ src/main.cpp      |  2 +-
+ src/path_info.cpp | 19 +++++++++++++++++++
+ 3 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 3de1a34..347e741 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,6 +37,8 @@
+ #  make install
+ # Enable lua support. Required only for full-fledged mods.
+ #  make LUA=1
++# Use user's XDG base directories for save files and configs.
++#  make USE_XDG_DIR=1
+ # Use user's home directory for save files.
+ #  make USE_HOME_DIR=1
+ # Use dynamic linking (requires system libraries).
+@@ -407,9 +409,19 @@ ifeq ($(TARGETSYSTEM), CYGWIN)
+ endif
+ 
+ ifeq ($(USE_HOME_DIR),1)
++  ifeq ($(USE_XDG_DIR),1)
++    $(error "USE_HOME_DIR=1 does not work with USE_XDG_DIR=1")
++  endif
+   DEFINES += -DUSE_HOME_DIR
+ endif
+ 
++ifeq ($(USE_XDG_DIR),1)
++  ifeq ($(USE_HOME_DIR),1)
++    $(error "USE_HOME_DIR=1 does not work with USE_XDG_DIR=1")
++  endif
++  DEFINES += -DUSE_XDG_DIR
++endif
++
+ all: version $(TARGET) $(L10N)
+ 	@
+ 
+diff --git a/src/main.cpp b/src/main.cpp
+index 756e36a..aafb244 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
+     PATH_INFO::init_base_path("");
+ #endif
+ 
+-#ifdef USE_HOME_DIR
++#if (defined USE_HOME_DIR || defined USE_XDG_DIR)
+     PATH_INFO::init_user_dir();
+ #else
+     PATH_INFO::init_user_dir("./");
+diff --git a/src/path_info.cpp b/src/path_info.cpp
+index 6c0410a..f40469c 100644
+--- a/src/path_info.cpp
++++ b/src/path_info.cpp
+@@ -34,6 +34,13 @@ void PATH_INFO::init_user_dir(const char *ud)
+ #elif defined MACOSX && defined TILES
+         user_dir = getenv( "HOME" );
+         dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm/";
++#elif (defined USE_XDG_DIR)
++        if ( (user_dir = getenv("XDG_DATA_HOME")) ) {
++            dir = std::string(user_dir) + "/cataclysm-dda/";
++        } else {
++            user_dir = getenv("HOME");
++            dir = std::string(user_dir) + "/.local/share/cataclysm-dda/";
++        }
+ #else
+         user_dir = getenv("HOME");
+         dir = std::string(user_dir) + "/.cataclysm-dda/";
+@@ -144,7 +151,19 @@ void PATH_INFO::set_standard_filenames(void)
+     update_pathname("savedir", FILENAMES["user_dir"] + "save/");
+     update_pathname("memorialdir", FILENAMES["user_dir"] + "memorial/");
+     update_pathname("templatedir", FILENAMES["user_dir"] + "templates/");
++#ifdef USE_XDG_DIR
++    const char *user_dir;
++    std::string dir;
++    if ( (user_dir = getenv("XDG_CONFIG_HOME")) ) {
++        dir = std::string(user_dir) + "/cataclysm-dda/";
++    } else {
++        user_dir = getenv("HOME");
++        dir = std::string(user_dir) + "/.config/cataclysm-dda/";
++    }
++    update_pathname("config_dir", dir);
++#else
+     update_pathname("config_dir", FILENAMES["user_dir"] + "config/");
++#endif
+     update_pathname("graveyarddir", FILENAMES["user_dir"] + "graveyard/");
+ 
+     update_pathname("options", FILENAMES["config_dir"] + "options.txt");
+-- 
+2.7.3
+


### PR DESCRIPTION
Fixes #43 

The patch seems to work fine. I also added a warning when upgrading from the prior version in pkg_postinst().

The more I thought about it, the more I think you probably wouldn't want to modify the 0.9c behavior, but here's that patch anyway, in case you want to pull it.