### PR TITLE
Update cataclysm-dda-9999-r6.ebuild

### DIFF
--- a/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r6.ebuild
+++ b/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r6.ebuild
@@ -214,8 +214,10 @@ src_compile() {
 			# Enabling tiled output implicitly enables SDL.
 			TILES=1
 
-			# Conditionally set USE flag-dependent SDL options.
-			SOUND=$(usex sound 1 0)
+			# Sound requires SDL
+			if use sound; then
+				SOUND=1
+			fi
 		)
 
 		# Compile us up the tiled bomb.


### PR DESCRIPTION
As detailed on https://github.com/CleverRaven/Cataclysm-DDA/issues/24112, makefile doesn't check the value of the SOUND variable, only if it was defined.