### PR TITLE
app-misc/powerline: add python3.8 target

### DIFF
--- a/app-misc/powerline/powerline-9999-r20.ebuild
+++ b/app-misc/powerline/powerline-9999-r20.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy{,3} )
+PYTHON_COMPAT=( python2_7 python3_{5,6,7,8} pypy{,3} )
 
 # Since default phase functions defined by "distutils-r1" take absolute
 # precedence over those defined by "readme.gentoo-r1", inherit the latter later.


### PR DESCRIPTION
I added a python3.8 target because for some reason portage pulls in 3.8 even if it's not set as a python target and vim decides to use that. I tested it on my machine and it seems to work fine.