### PR TITLE
Update zeronet-0.7.1-r3.ebuild

### DIFF
--- a/net-vpn/zeronet/zeronet-0.7.1-r3.ebuild
+++ b/net-vpn/zeronet/zeronet-0.7.1-r3.ebuild
@@ -364,7 +364,6 @@ errors will be displayed on attempting to browse with any other browser.
 	fowners ${PN}:${PN} \
 		"${ZERONET_CONF_FILE}" \
 		"${ZERONET_LOG_DIR}" \
-		"${ZERONET_LOG_DIR}/"* \
 		|| die '"fowners" failed.'
 	shopt -u nullglob
 


### PR DESCRIPTION
Fix for
```
>>> Install net-vpn/zeronet-0.7.1-r3 into /var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/cmd.log': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug-last.log': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log.2020-12-22': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log.2020-12-23': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log.2020-12-24': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log.2020-12-25': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/debug.log.2020-12-27': No such file or directory
chown: cannot access '/var/tmp/portage/net-vpn/zeronet-0.7.1-r3/image/var/log/zeronet/error.log': No such file or directory

ERROR: net-vpn/zeronet-0.7.1-r3::raiagent failed (install phase):
   fowners failed
```