### PR TITLE
games-roguelike/cataclysm-dda: fixes

### DIFF
--- a/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r9.ebuild
+++ b/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r9.ebuild
@@ -94,6 +94,14 @@ else
 	KEYWORDS="~amd64 ~x86"
 
 	S="${WORKDIR}/Cataclysm-DDA-${MY_PV}"
+
+	# Fixed upstream for next release, but GCC13 still breaks in this one.
+	# cf. https://github.com/CleverRaven/Cataclysm-DDA/pull/66195
+	if [[ ${PV} == "0.9g" ]]; then
+		PATCHES=(
+			"${FILESDIR}/${PN}-0.9g-gcc13-compat.patch"
+		)
+	fi
 fi
 
 src_prepare() {

--- a/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r9.ebuild
+++ b/games-roguelike/cataclysm-dda/cataclysm-dda-9999-r9.ebuild
@@ -34,15 +34,11 @@ REQUIRED_USE="
 	pch? ( ^^ ( ncurses sdl ) )
 	sound? ( sdl )
 "
-
-# Note that, while GCC also supports LTO via the gold linker, Portage appears
-# to provide no way of validating the current "gcc" to link with gold. *shrug*
 IDEPEND="dev-util/desktop-file-utils"
 BDEPEND="
 	clang? (
 		sys-devel/clang
 		debug? ( sys-devel/clang-runtime[sanitize] )
-		lto?   ( sys-devel/llvm[gold] )
 	)
 	!clang? (
 		sys-devel/gcc[cxx]
@@ -258,7 +254,10 @@ src_compile() {
 	use clang && CATACLYSM_EMAKE_NCURSES+=( CLANG=1 )
 
 	# If enabling link time optimization, do so.
-	use lto && CATACLYSM_EMAKE_NCURSES+=( LTO=1 )
+	# Use of the Gold linker is optional, but offers no improvement with LTO
+	# over BFD and is in bitrot; here we disable Makefile's preference for it.
+	# Alternate linkers can/should be controlled via /etc/portage/package.env.
+	use lto && CATACLYSM_EMAKE_NCURSES+=( LTO=1 GOLD=0 )
 
 	# If enabling debugging-specific facilities, do so. Specifically,
 	# * "RELEASE=0", disabling release-specific optimizations.

--- a/games-roguelike/cataclysm-dda/files/cataclysm-dda-0.9g-gcc13-compat.patch
+++ b/games-roguelike/cataclysm-dda/files/cataclysm-dda-0.9g-gcc13-compat.patch
@@ -1,0 +1,12 @@
+diff --git a/src/translation_document.h b/src/translation_document.h
+index 1e20f6629a09e..71ebb499a9ab5 100644
+--- a/src/translation_document.h
++++ b/src/translation_document.h
+@@ -4,6 +4,7 @@
+ 
+ #if defined(LOCALIZE)
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ #include <vector>


### PR DESCRIPTION
Hello! I come bearing gifts.

There are two separate fixes offered here for the Cataclysm: DDA ebuild.

- Compiling with `USE=lto` was broken because of reorganized dependencies in ::gentoo. This fix removes a dependency previously required for LTO that is required no longer, and suggests a more _Gentoo-esque_ means of involving alternate linkers if the user so desires. I benchmarked this ebuild with GCC and Clang and four different linkers (BFD, Gold, LLD, and Mold) to reach my conclusions.
- Compiling with GCC 13 was broken because of reorganized libraries in the C++ standard namespace.

Full details and justifications are in the commit messages.